### PR TITLE
Preparing for stabilization of fN::BITS

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -980,7 +980,8 @@ macro_rules! impl_float {
     ($($ty:ty, $aty:ty, $zero:expr, $one:expr,)*) => {$(
 
 impl AsBytes for $aty {
-    const BITS: usize = <$ty>::BITS;
+    #[expect(clippy::unnecessary_cast, reason = "Preparing for stabilization of fN::BITS.")]
+    const BITS: usize = <$ty>::BITS as usize;
     const BYTES: usize = <$ty>::BYTES;
     type Bytes = [u8;  <$ty>::BYTES];
 }


### PR DESCRIPTION
Adds an `as usize` to prevent an error caused by the stabilization of `fN::BITS`.

Uncovered by: https://crater-reports.s3.amazonaws.com/pr-154065/try%230abe69e6c16114311cc2700e972492e64d69c28f/reg/cseq_benchmark-0.1.6/log.txt.